### PR TITLE
Adds commands to restart services

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ sudo systemctl restart nautobot nautobot-worker
 
 ## Upgrades
 
-When a new release comes out it may be necessary to run a migration of the database to account for any changes in the data models used by this plugin. Execute the command `nautobot-server migrate` from the Nautobot install `nautobot/` directory after updating the package.
+When upgrading to a new version of this plugin, it may be necessary to run database migrations, copy new static files, and so forth. These will all be handled by executing the command `nautobot-server post_upgrade` from the Nautobot install `nautobot/` directory after updating the plugin package.
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The plugin behavior can be controlled with the following list of settings:
 
 - `enable_devicetype-library`: If enabled the [device type](https://github.com/netbox-community/devicetype-library) git repository will be automatically added for you.
 
-After updating nautobot_config.py, you will need to run `nautobot-server migrate` and then reload the nautobot service and the nautobot-worker service as shown below.
+After updating nautobot_config.py, you will need to run `nautobot-server post_upgrade` and then reload the nautobot service and the nautobot-worker service as shown below.
 
 ### Final Configuration Steps
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,26 @@ The plugin behavior can be controlled with the following list of settings:
 
 - `enable_devicetype-library`: If enabled the [device type](https://github.com/netbox-community/devicetype-library) git repository will be automatically added for you.
 
-After updating nautobot_config.py, you will need to run `nautobot-server migrate` and then reload the nautobot service and the nautobot-worker service.
+After updating nautobot_config.py, you will need to run `nautobot-server migrate` and then reload the nautobot service and the nautobot-worker service as shown below.
+
+### Final Configuration Steps
+
+After installing the plugin and modifying `nautobot_config.py`, as the `nautobot` user, run the server migration:
+
+```no-highlight
+$ nautobot-server migrate
+```
+
+Finally, as root, restart Nautobot and the Nautobot worker.
+
+```no-highlight
+$ sudo systemctl restart nautobot nautobot-worker
+```
+
+## Upgrades
+
+When a new release comes out it may be necessary to run a migration of the database to account for any changes in the data models used by this plugin. Execute the command `nautobot-server migrate` from the Nautobot install `nautobot/` directory after updating the package.
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ After updating nautobot_config.py, you will need to run `nautobot-server migrate
 After installing the plugin and modifying `nautobot_config.py`, as the `nautobot` user, run the server migration:
 
 ```no-highlight
-$ nautobot-server migrate
+$ nautobot-server post_upgrade
 ```
 
 Finally, as root, restart Nautobot and the Nautobot worker.


### PR DESCRIPTION
While installing the plugin through the readme I had missed the part about running migrations. This is because for me, my typical install process follows all of the commands that can be copied from a command snippet over to the install window. The steps for migrations and restarting the services were not included originally. Including.