### PR TITLE
Correct bug in Device and Manufacturer list views.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python in the build environment.
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# MKDocs configuration file
+mkdocs:
+  configuration: mkdocs.yml
+
+# Use our docs/requirements.txt during installation.
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,4 @@
+---
 # .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
@@ -7,15 +8,15 @@ version: 2
 
 # Set the version of Python in the build environment.
 build:
-  os: ubuntu-20.04
+  os: "ubuntu-20.04"
   tools:
     python: "3.9"
 
 # MKDocs configuration file
 mkdocs:
-  configuration: mkdocs.yml
+  configuration: "mkdocs.yml"
 
 # Use our docs/requirements.txt during installation.
 python:
   install:
-    - requirements: docs/requirements.txt
+    - requirements: "docs/requirements.txt"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-mkdocs==1.1
+mkdocs==1.2.3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,9 +4,6 @@ edit_uri: "edit/main/welcome_wizard/docs"
 site_name: "Nautobot Welcome Wizard Documentation"
 site_url: "https://nautobot-plugin-welcome-wizard.readthedocs.io/"
 repo_url: "https://github.com/nautobot/nautobot-plugin-welcome-wizard"
-python:
-  install:
-    - requirements: "docs/requirements.txt"
 theme:
   name: "readthedocs"
   navigation_depth: 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-welcome-wizard"
-version = "1.0.3"
+version = "1.0.4"
 description = "Nautobot's Welcome Wizard"
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 
@@ -35,7 +35,7 @@ pydocstyle = "*"
 flake8 = "*"
 django-debug-toolbar = "*"
 coverage = "*"
-mkdocs = "^1.1.2"
+mkdocs = "^1.2.3"
 coverage-badge = "^1.0.1"
 
 [tool.black]

--- a/welcome_wizard/__init__.py
+++ b/welcome_wizard/__init__.py
@@ -1,6 +1,6 @@
 """Plugin declaration for Welcome Wizard."""
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 from django.db.models.signals import post_migrate
 from nautobot.extras.plugins import PluginConfig

--- a/welcome_wizard/tables.py
+++ b/welcome_wizard/tables.py
@@ -39,7 +39,7 @@ DASHBOARD_LINK = """
 """
 
 
-class ManufacturerTable(BaseTable):
+class ManufacturerWizardTable(BaseTable):
     """Table to show the ManufactureImport List."""
 
     pk = ToggleColumn()
@@ -57,7 +57,7 @@ class ManufacturerTable(BaseTable):
             empty_text = "Adding data from GitRepository, please refresh"
 
 
-class DeviceTypeTable(BaseTable):
+class DeviceTypeWizardTable(BaseTable):
     """Table to show the DeviceTypeImport List."""
 
     pk = ToggleColumn()

--- a/welcome_wizard/views.py
+++ b/welcome_wizard/views.py
@@ -28,14 +28,14 @@ from welcome_wizard.forms import (
 from welcome_wizard.jobs import WelcomeWizardImportDeviceType, WelcomeWizardImportManufacturer
 from welcome_wizard.models.importer import ManufacturerImport, DeviceTypeImport
 from welcome_wizard.models.merlin import Merlin
-from welcome_wizard.tables import ManufacturerTable, DeviceTypeTable, DashboardTable
+from welcome_wizard.tables import ManufacturerWizardTable, DeviceTypeWizardTable, DashboardTable
 
 
 class ManufacturerListView(generic.ObjectListView):
     """Table of all Manufacturers discovered in the Git Repository."""
 
     permission_required = "welcome_wizard.view_manufacturerimport"
-    table = ManufacturerTable
+    table = ManufacturerWizardTable
     queryset = ManufacturerImport.objects.all()
     action_buttons = None
     template_name = "welcome_wizard/manufacturer.html"
@@ -58,7 +58,7 @@ class DeviceTypeListView(generic.ObjectListView):
     """Table of Device Types based on the Manufacturer."""
 
     permission_required = "welcome_wizard.view_devicetypeimport"
-    table = DeviceTypeTable
+    table = DeviceTypeWizardTable
     queryset = DeviceTypeImport.objects.prefetch_related("manufacturer")
     filterset = DeviceTypeImportFilterSet
     action_buttons = None


### PR DESCRIPTION
FIXES: #49 

The name of the tables were the same tables used
in Nautobot, so when a Nautobot table had custom
preferences, these preferences got applied to the
DeviceType Import Wizard and Manufacturer Import
Wizard view.

This also upgrades mkdocs to get around mkdocs
security issue.