### PR TITLE
Cluster fix add devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,16 @@ PLUGINS = ["welcome_wizard"]
 
 # PLUGINS_CONFIG = {
 #   "welcome_wizard": {
-#     "enable_devicetype-library": True
+#     "enable_devicetype-library": True,
+#     "enable_welcome_banner": True,
 #   }
 # }
 ```
 
 The plugin behavior can be controlled with the following list of settings:
 
-- `enable_devicetype-library`: If enabled the [device type](https://github.com/netbox-community/devicetype-library) git repository will be automatically added for you.
+- `enable_devicetype-library`: If enabled, the [device type](https://github.com/netbox-community/devicetype-library) git repository will be automatically added for you.
+- `enable_welcome_banner`: If enabled, the Welcome Wizard banner will display on the home screen for authenticated users.
 
 After updating nautobot_config.py, you will need to run `nautobot-server post_upgrade` and then reload the nautobot service and the nautobot-worker service as shown below.
 

--- a/welcome_wizard/__init__.py
+++ b/welcome_wizard/__init__.py
@@ -19,6 +19,7 @@ class WelcomeWizardConfig(PluginConfig):
     default_settings = {
         # Add devicetype-library to Nautobot Git Repositories
         "enable_devicetype-library": True,
+        "enable_welcome_banner": True,
     }
     caching_config = {}
     middleware = ["welcome_wizard.middleware.Prerequisites"]

--- a/welcome_wizard/banner.py
+++ b/welcome_wizard/banner.py
@@ -1,6 +1,7 @@
 """Home page banner for Welcome Wizard."""
 from typing import Optional
 
+from django.conf import settings
 from django.urls import reverse
 from django.utils.html import format_html
 
@@ -15,6 +16,7 @@ def banner(context, *args, **kwargs) -> Optional[PluginBanner]:
     These conditions must be met:
     - If User has permissions to the Welcome Wizard Dashboard (merlin)
     - On the Nautobot Home Page
+    - enable_welcome_banner setting is True
     """
     required_permission = "welcome_wizard.view_merlin"
 
@@ -22,6 +24,7 @@ def banner(context, *args, **kwargs) -> Optional[PluginBanner]:
         context.request.path == "/"
         and context.request.user.is_authenticated
         and context.request.user.has_perms((required_permission,))
+        and settings.PLUGINS_CONFIG["welcome_wizard"].get("enable_welcome_banner")
     ):
         content = format_html(
             '<a href="{}">The Nautobot Welcome Wizard can help you get started with Nautobot!</a>',

--- a/welcome_wizard/middleware.py
+++ b/welcome_wizard/middleware.py
@@ -18,8 +18,7 @@ class Prerequisites:
 
     def __call__(self, request):
         """Capture the response and return it."""
-        response = self.get_request(request)
-        return response
+        return self.get_request(request)
 
     def process_view(self, request, view_func, view_args, view_kwargs):  # pylint: disable=W0613,R0201
         """Process the view to determine if it's one we want to intercept."""
@@ -28,20 +27,25 @@ class Prerequisites:
             return
         if request.path.endswith("/add/"):
             # Check if using a Nautobot view class.
-            if not (hasattr(view_func, "view_class") and hasattr(view_func.view_class, "model_form")):
+            if not (
+                hasattr(view_func, "view_class")
+                and hasattr(view_func.view_class, "model_form")
+                and view_func.view_class.model_form is not None
+            ):
                 return
             base_fields = view_func.view_class.model_form.base_fields
             for field in base_fields:
-                if base_fields[field].required:
-                    if hasattr(base_fields[field], "queryset") and not base_fields[field].queryset.exists():
-                        name = base_fields[field].label if base_fields[field].label else field.replace("_", " ").title()
-                        reverse_name = field.replace("_", "")
-                        try:
-                            reverse_link = reverse(f"{request.resolver_match.app_names[0]}:{reverse_name}_add")
-                        except NoReverseMatch as error:
-                            logger.warning("No Reverse Match was found for %s. %s", reverse_name, error)
-                            reverse_link = ""
-                        msg = (
-                            f"You need to configure a <a href='{reverse_link}'>{name}</a> before you create this item."
-                        )
-                        messages.error(request, mark_safe(msg))  # nosec
+                if (
+                    base_fields[field].required
+                    and hasattr(base_fields[field], "queryset")
+                    and not base_fields[field].queryset.exists()
+                ):
+                    name = base_fields[field].label or field.replace("_", " ").title()
+                    reverse_name = field.replace("_", "")
+                    try:
+                        reverse_link = reverse(f"{request.resolver_match.app_names[0]}:{reverse_name}_add")
+                    except NoReverseMatch as error:
+                        logger.warning("No Reverse Match was found for %s. %s", reverse_name, error)
+                        reverse_link = ""
+                    msg = f"You need to configure a <a href='{reverse_link}'>{name}</a> before you create this item."
+                    messages.error(request, mark_safe(msg))  # nosec

--- a/welcome_wizard/tests/test_views.py
+++ b/welcome_wizard/tests/test_views.py
@@ -14,6 +14,7 @@ from nautobot.dcim.models import Manufacturer, DeviceType
 from nautobot.dcim.models.sites import Site
 from nautobot.utilities.testing import TransactionTestCase
 from nautobot.utilities.testing.views import TestCase
+from nautobot.virtualization.models import Cluster, ClusterType
 
 from welcome_wizard.models.importer import DeviceTypeImport, ManufacturerImport
 
@@ -440,4 +441,17 @@ class BannerTestCase(TestCase):
         self.assertNotContains(
             response,
             '<a href="/plugins/welcome_wizard/dashboard/">The Nautobot Welcome Wizard can help you get started with Nautobot!</a>',
+        )
+
+
+class ClusterDevicesTestCase(TestCase):
+    """Ensure Cluster Add Devices view loads (https://github.com/nautobot/nautobot-plugin-welcome-wizard/issues/62)."""
+
+    def test_cluster_add_devices(self):
+        self.add_permissions("virtualization.change_cluster")
+        cluster_type = ClusterType.objects.create(name="Cluster Type 1", slug="cluster-type-1")
+        cluster = Cluster.objects.create(name="Cluster 1", type=cluster_type)
+
+        self.assertHttpStatus(
+            self.client.get(reverse("virtualization:cluster_add_devices", kwargs={"pk": cluster.pk})), 200
         )


### PR DESCRIPTION
Fixes #62 

This PR fixes the `AttributeError` on any `add` form that does not use base_fields (e.x. ClusterAddDeviceForm).
This also makes the Welcome Banner optional (configurable in settings).