### PR TITLE
Changed extends base.html to extends generic/object_list.html

### DIFF
--- a/docs/dev/release_checklist.md
+++ b/docs/dev/release_checklist.md
@@ -49,7 +49,7 @@ Add the release notes (`docs/release-notes/X.Y.md`) to the table of contents wit
 
 ### Verify and Revise the Install Documentation
 
-Follow the [install instructions](../admin/install/index.md) to perform a new production installation of Nautobot ChatOps.
+Follow the [install instructions](../admin/install.md) to perform a new production installation of Nautobot ChatOps.
 
 The goal of this step is to walk through the entire install process *as documented* to make sure nothing there needs to be changed or updated, to catch any errors or omissions in the documentation, and to ensure that it is current with each release.
 

--- a/welcome_wizard/templates/welcome_wizard/dashboard.html
+++ b/welcome_wizard/templates/welcome_wizard/dashboard.html
@@ -1,26 +1,7 @@
 {% extends 'generic/object_list.html' %}
-{% load buttons %}
-{% load custom_links %}
-{% load helpers %}
-{% load plugins %}
-{% load static %}
-{% load tz %}
 
-{% block header %}
-    <div class="row noprint">
-        <div class="col-sm-9">
-            <ol class="breadcrumb">
-                <li><a href="{% url 'plugins:welcome_wizard:dashboard' %}">Dashboard</a></li>
-            </ol>
-        </div>
-    </div>
+{% block breadcrumbs %}
+    <li><a href="{% url 'plugins:welcome_wizard:dashboard' %}">Dashboard</a></li>
 {% endblock %}
 
-{% block content %}
-<h1>{% block title %}Welcome Wizard{% endblock %}</h1>
-<div class="row">
-    <div class="col-md-9">
-        {% include 'utilities/obj_table.html' %}
-    </div>
-</div>
-{% endblock %}
+{% block title %}Welcome Wizard{% endblock %}

--- a/welcome_wizard/templates/welcome_wizard/dashboard.html
+++ b/welcome_wizard/templates/welcome_wizard/dashboard.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'generic/object_list.html' %}
 {% load buttons %}
 {% load custom_links %}
 {% load helpers %}

--- a/welcome_wizard/tests/test_views.py
+++ b/welcome_wizard/tests/test_views.py
@@ -355,7 +355,8 @@ class DashboardView(TestCase):
         self.assertHttpStatus(resp, 200)
         self.assertContains(resp, "Dashboard")
         self.assertContains(resp, "mdi-wizard-hat", 2)
-        self.assertContains(resp, "mdi-plus-thick", 8)
+        # 9th is from nautobot formset javascript
+        self.assertContains(resp, "mdi-plus-thick", 9)
         self.assertContains(resp, "mdi-checkbox-blank-outline", 8)
         self.assertContains(resp, "mdi-checkbox-marked-outline", 0)
 
@@ -369,7 +370,8 @@ class DashboardView(TestCase):
         self.assertHttpStatus(resp, 200)
         self.assertContains(resp, "Dashboard")
         self.assertContains(resp, "mdi-wizard-hat", 2)
-        self.assertContains(resp, "mdi-plus-thick", 8)
+        # 9th is from nautobot formset javascript
+        self.assertContains(resp, "mdi-plus-thick", 9)
         self.assertContains(resp, "mdi-checkbox-blank-outline", 6)
         self.assertContains(resp, "mdi-checkbox-marked-outline", 2)
 

--- a/welcome_wizard/views.py
+++ b/welcome_wizard/views.py
@@ -272,6 +272,13 @@ class WelcomeWizardDashboard(generic.ObjectListView):
         self.check_data()
         return super().get(request, *args, **kwargs)
 
+    def extra_context(self):
+        """Override search and table config."""
+        return {
+            "table_config_form": None,
+            "search_form": None,
+        }
+
     permission_required = "welcome_wizard.view_merlin"
     queryset = Merlin.objects.all()
     template_name = "welcome_wizard/dashboard.html"


### PR DESCRIPTION
Fixes: #69 

Changed `extends 'base.html'` to `extends 'generic/object_detail.html'` in templates/welcome_wizard/dashbaord.html