### PR TITLE
Check GitHub actions deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   black:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       INVOKE_WELCOME_WIZARD_LOCAL: "True"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ env:
 
 jobs:
   black:
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-20.04"
     env:
       INVOKE_WELCOME_WIZARD_LOCAL: "True"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v4"
       - name: "Linting: black"


### PR DESCRIPTION
# About

This PR should resolve https://github.com/networktocode-llc/cookiecutter-ntc/issues/307

## Done

- Use Ubuntu 22.04 image for GH runners (black)