### PR TITLE
NAPPS-1051 Fix import device types manufacturer filter

### DIFF
--- a/changes/174.fixed
+++ b/changes/174.fixed
@@ -1,0 +1,1 @@
+Fixed the manufacturer filter on the Device Types import list returning no results when filtering by manufacturer name.

--- a/welcome_wizard/filters.py
+++ b/welcome_wizard/filters.py
@@ -34,7 +34,7 @@ class DeviceTypeImportFilterSet(NautobotFilterSet):  # pylint: disable=too-many-
     manufacturer = NaturalKeyOrPKMultipleChoiceFilter(
         to_field_name="name",
         queryset=models.ManufacturerImport.objects.all(),
-        field_name="manufacturer__name",
+        field_name="manufacturer",
         label="Manufacturer",
     )
 

--- a/welcome_wizard/tests/test_filters.py
+++ b/welcome_wizard/tests/test_filters.py
@@ -67,12 +67,15 @@ class DeviceTypeTestCase(TestCase):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_manufacturer(self):
-        """Test filtering by Manufacturer."""
-        manufacturers = ManufacturerImport.objects.all()[:2]
-        params = {"manufacturer_id": [manufacturers[0].pk, manufacturers[1].pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
-        params = {"manufacturers": [manufacturers[0].name, manufacturers[1].name]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+        """Test filtering by Manufacturer name.
+
+        Regression test: filtering by manufacturer name returned an empty list because the
+        filter's `field_name` was `manufacturer__name` instead of the FK field `manufacturer`.
+        """
+        params = {"manufacturer": ["Test"]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {"manufacturer": ["Acme"]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_search(self):
         """Test the search ability."""

--- a/welcome_wizard/tests/test_filters.py
+++ b/welcome_wizard/tests/test_filters.py
@@ -1,6 +1,7 @@
 """Test Welcome Wizard Filters."""
 
 from django.test import TestCase
+from nautobot.apps.testing import TestCase as NautobotTestCase
 
 from welcome_wizard.filters import DeviceTypeImportFilterSet, ManufacturerImportFilterSet
 from welcome_wizard.models.importer import DeviceTypeImport, ManufacturerImport
@@ -30,7 +31,7 @@ class ManufacturerTestCase(TestCase):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
 
-class DeviceTypeTestCase(TestCase):
+class DeviceTypeTestCase(NautobotTestCase):
     """DeviceTypeImport Filters."""
 
     queryset = DeviceTypeImport.objects.all()
@@ -72,15 +73,24 @@ class DeviceTypeTestCase(TestCase):
         Regression test: filtering by manufacturer name returned an empty list because the
         filter's `field_name` was `manufacturer__name` instead of the FK field `manufacturer`.
         """
-        params = {"manufacturer": ["Test"]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-        params = {"manufacturer": ["Acme"]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        self.assertQuerysetEqualAndNotEmpty(
+            self.filterset({"manufacturer": ["Test"]}, self.queryset).qs,
+            self.queryset.filter(manufacturer__name="Test"),
+            ordered=False,
+        )
+        self.assertQuerysetEqualAndNotEmpty(
+            self.filterset({"manufacturer": ["Acme"]}, self.queryset).qs,
+            self.queryset.filter(manufacturer__name="Acme"),
+            ordered=False,
+        )
 
         # NaturalKeyOrPKMultipleChoiceFilter also supports filtering by primary key.
         test = ManufacturerImport.objects.get(name="Test")
-        params = {"manufacturer": [test.pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertQuerysetEqualAndNotEmpty(
+            self.filterset({"manufacturer": [test.pk]}, self.queryset).qs,
+            self.queryset.filter(manufacturer=test),
+            ordered=False,
+        )
 
     def test_search(self):
         """Test the search ability."""

--- a/welcome_wizard/tests/test_filters.py
+++ b/welcome_wizard/tests/test_filters.py
@@ -77,6 +77,11 @@ class DeviceTypeTestCase(TestCase):
         params = {"manufacturer": ["Acme"]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
+        # NaturalKeyOrPKMultipleChoiceFilter also supports filtering by primary key.
+        test = ManufacturerImport.objects.get(name="Test")
+        params = {"manufacturer": [test.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
     def test_search(self):
         """Test the search ability."""
         params = {"q": "test"}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Welcome Wizard! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #NAPPS-1051

## What's Changed

Fixes the manufacturer filter on the Device Types import list (`/plugins/welcome_wizard/devicetypes/`), which returned an empty table whenever a manufacturer was selected (even for manufacturers clearly present in the unfiltered list).

The bug was caused because `DeviceTypeImportFilterSet.manufacturer` was a `NaturalKeyOrPKMultipleChoiceFilter` with `to_field_name="manufacturer__name"`.  `NaturalKeyOrPKMultipleChoiceFilter` appends `to_field_name` to `field_name` when building a lookup for filtering by a natural key and that caused the lookup to be `manufacturer__name__name`.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
